### PR TITLE
SystemUI: DestroyContext in SystemUI Destructor.

### DIFF
--- a/Source/Urho3D/SystemUI/SystemUI.cpp
+++ b/Source/Urho3D/SystemUI/SystemUI.cpp
@@ -117,6 +117,7 @@ SystemUI::~SystemUI()
 {
     ImGui::EndFrame();
     ImGui::Shutdown(ImGui::GetCurrentContext());
+    ImGui::DestroyContext();
 }
 
 void SystemUI::UpdateProjectionMatrix()


### PR DESCRIPTION
Fixes Memory Leak