### PR TITLE
ProcessUtils: Fix ParseArguments() not evaluating entire expression i…

### DIFF
--- a/Source/Urho3D/Core/ProcessUtils.cpp
+++ b/Source/Urho3D/Core/ProcessUtils.cpp
@@ -278,7 +278,7 @@ const Vector<String>& ParseArguments(const String& cmdLine, bool skipFirstArgume
     {
         if (cmdLine[i] == '\"')
             inQuote = !inQuote;
-        if (cmdLine[i] == ' ' && !inQuote)
+        if ((cmdLine[i] == ' ' || (i == cmdLine.Length()-1)) && !inQuote)
         {
             if (inCmd)
             {


### PR DESCRIPTION
Fixes ParseArguments() not evaluating entire expression if there was not a space character at the end of the command line.