### PR TITLE
AssetViewer: Move ui::GetIO() from Setup To Start() because it was th…

### DIFF
--- a/Source/Tools/AssetViewer/AssetViewer.cpp
+++ b/Source/Tools/AssetViewer/AssetViewer.cpp
@@ -64,11 +64,13 @@ public:
         engineParameters_[EP_RESOURCE_PREFIX_PATHS] = ";..;../..";
         engineParameters_[EP_WINDOW_RESIZABLE] = true;
 
-        ui::GetIO().IniFilename = nullptr;    // Disable saving of settings.
+        
     }
 
     void Start() override
     {
+        ui::GetIO().IniFilename = nullptr;    // Disable saving of settings.
+
         GetInput()->SetMouseVisible(true);
         GetInput()->SetMouseMode(MM_ABSOLUTE);
 


### PR DESCRIPTION
AssetViewer: Move ui::GetIO() from Setup To Start() because it was throwing an expection that the ImGui Context had not yet been created.