### PR TITLE
Enable Debug Native code by default - C# projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
   <PropertyGroup>
     <PlatformTarget Condition=" '$(PlatformTarget)' == '' ">x64</PlatformTarget>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+	<EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(BuildDir)' == '' ">
     <BuildDir Condition=" '$(OS)' != 'Unix' ">$(SolutionDir)/</BuildDir>


### PR DESCRIPTION
Works for .Net with Visual Studio 2017.

Does not work with .Net Core as per https://github.com/dotnet/project-system/issues/1125